### PR TITLE
fix(forms): pin @hookform/resolvers 4.1.3

### DIFF
--- a/packages/saas-ui-forms/package.json
+++ b/packages/saas-ui-forms/package.json
@@ -81,7 +81,7 @@
     "url": "https://storybook.saas-ui.dev"
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.0.0",
+    "@hookform/resolvers": "4.1.3",
     "@saas-ui/core": "workspace:*",
     "@saas-ui/react": "workspace:*",
     "@standard-schema/spec": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,8 +505,8 @@ importers:
         specifier: '>=11.0.0'
         version: 11.14.0(@types/react@19.0.12)(react@19.0.0)
       '@hookform/resolvers':
-        specifier: ^5.0.0
-        version: 5.0.1(react-hook-form@7.57.0(react@19.0.0))
+        specifier: 4.1.3
+        version: 4.1.3(react-hook-form@7.57.0(react@19.0.0))
       '@saas-ui/core':
         specifier: workspace:*
         version: link:../saas-ui-core
@@ -1998,11 +1998,6 @@ packages:
     resolution: {integrity: sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ==}
     peerDependencies:
       react-hook-form: ^7.0.0
-
-  '@hookform/resolvers@5.0.1':
-    resolution: {integrity: sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==}
-    peerDependencies:
-      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -10290,7 +10285,7 @@ snapshots:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.54.2(react@19.0.0)
 
-  '@hookform/resolvers@5.0.1(react-hook-form@7.57.0(react@19.0.0))':
+  '@hookform/resolvers@4.1.3(react-hook-form@7.57.0(react@19.0.0))':
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.57.0(react@19.0.0)


### PR DESCRIPTION
## Summary
- fix(forms): pin @hookform/resolvers 4.1.3 to avoid upgrade issues
- sync pnpm-lock after dependency change

## Testing
- `pnpm dev:web`
- `pnpm lint` *(fails: command exited (1))*
- `pnpm test` *(fails: Failed to resolve import "@saas-ui/test-utils")*

------
https://chatgpt.com/codex/tasks/task_e_689459dbed888330bf93e2130e97410e